### PR TITLE
[wip] remove interruption request

### DIFF
--- a/src/WasmModule/WasmModule.cpp
+++ b/src/WasmModule/WasmModule.cpp
@@ -252,6 +252,7 @@ void WasmModule::requestInterruption(vb::TrapCode const trapCode) VB_NOEXCEPT {
 #endif
 #if INTERRUPTION_REQUEST
     runtime_.requestInterruption(trapCode);
+    MemUtils::setPermissionRW(const_cast<uint8_t *>(executableMemory_.data()), executableMemory_.size());
 #else
     static_cast<void>(trapCode);
     UNREACHABLE(_, "Should not be called if interruption is not requested");

--- a/src/core/compiler/backend/aarch64/aarch64_backend.cpp
+++ b/src/core/compiler/backend/aarch64/aarch64_backend.cpp
@@ -1013,19 +1013,7 @@ void Backend::spillAllVariables(Stack::iterator const below) const {
 }
 
 #if INTERRUPTION_REQUEST
-void Backend::checkForInterruptionRequest(REG const scrReg) const {
-  as_.INSTR(LDURB_wT_deref_xN_unscSImm9_t)
-      .setT(scrReg)
-      .setN(WasmABI::REGS::linMem)
-      .setUnscSImm9(SafeInt<9>::fromConst<-BD::FromEnd::statusFlags>())();
-
-  RelPatchObj const statusFlagIsZero{as_.prepareJMPIfRegIsZero(scrReg, false)};
-  // Retrieve the trapCode from the actual flag
-  if (scrReg != WasmABI::REGS::trapReg) {
-    as_.INSTR(MOV_wD_wM_t).setD(WasmABI::REGS::trapReg).setM(scrReg)();
-  }
-  as_.TRAP(TrapCode::NONE);
-  statusFlagIsZero.linkToHere();
+void Backend::checkForInterruptionRequest(REG const) const {
 }
 #endif
 

--- a/src/core/compiler/backend/x86_64/x86_64_backend.cpp
+++ b/src/core/compiler/backend/x86_64/x86_64_backend.cpp
@@ -614,13 +614,6 @@ void Backend::spillAllVariables(Stack::iterator const below) const {
 
 #if INTERRUPTION_REQUEST
 void Backend::checkForInterruptionRequest() const {
-  as_.INSTR(CMP_rm8_imm8).setM4RM(WasmABI::REGS::linMem, -BD::FromEnd::statusFlags).setImm8(0x0U)();
-
-  RelPatchObj const relPatchObj{as_.prepareJMP(true, CC::E)};
-  // Retrieve the trapCode from the actual flag
-  as_.INSTR(MOVZX_r32_rm8_t).setR(WasmABI::REGS::trapReg).setM4RM(WasmABI::REGS::linMem, -BD::FromEnd::statusFlags)();
-  as_.TRAP(TrapCode::NONE, false);
-  relPatchObj.linkToHere();
 }
 #endif
 

--- a/src/core/runtime/Runtime.cpp
+++ b/src/core/runtime/Runtime.cpp
@@ -549,6 +549,12 @@ void Runtime::requestInterruption(TrapCode const trapCode) const VB_NOEXCEPT {
   uint8_t const rawTrapCode{static_cast<uint8_t>(static_cast<uint32_t>(trapCode))};
   *ptr = rawTrapCode;
 }
+TrapCode Runtime::getRequestInterruption() const VB_NOEXCEPT {
+  TrapCode trapCode{TrapCode::NONE};
+  uint8_t *const ptr{pSubI(getLinearMemoryBase(), Basedata::FromEnd::statusFlags)};
+  memcpy(&trapCode, ptr, sizeof(TrapCode));
+  return trapCode;
+}
 #endif
 
 void Runtime::resetTrapInfo() const VB_NOEXCEPT {

--- a/src/core/runtime/Runtime.hpp
+++ b/src/core/runtime/Runtime.hpp
@@ -41,6 +41,7 @@
 #include "src/core/common/VbExceptions.hpp"
 #include "src/core/common/basedataoffsets.hpp"
 #include "src/core/common/util.hpp"
+#include "src/utils/MemUtils.hpp"
 
 namespace vb {
 
@@ -363,6 +364,13 @@ public:
   /// default) NOTE: TrapCode::NONE will not lead to a trap
   ///
   NO_THREAD_SANITIZE void requestInterruption(TrapCode const trapCode = TrapCode::RUNTIME_INTERRUPT_REQUESTED) const VB_NOEXCEPT;
+  TrapCode getRequestInterruption() const VB_NOEXCEPT;
+
+  static void interruptRecoverHandler(Runtime &self) {
+    MemUtils::setPermissionRX(pRemoveConst(self.binaryModule_.getStartAddress()),
+                              static_cast<size_t>(self.binaryModule_.getEndAddress() - self.binaryModule_.getStartAddress()));
+    self.tryTrap(self.getRequestInterruption());
+  }
 #endif
 
 #if BUILTIN_FUNCTIONS

--- a/src/utils/SignalFunctionWrapper_unix.cpp
+++ b/src/utils/SignalFunctionWrapper_unix.cpp
@@ -303,7 +303,14 @@ void SignalFunctionWrapperUnix::memorySignalHandler(int32_t const signalId, sigi
 #else
     static_cast<void>(si);
 #endif
-
+    if (trapCode == 0) {
+      trapCode = static_cast<uint32_t>(SignalFunctionWrapper::pRuntime_->getRequestInterruption());
+      if (trapCode != 0U) {
+        setReturnFromSignalHandler(uc, pCast<void const *>(&Runtime::interruptRecoverHandler));
+        setParamsForReturn(uc, (uint64_t)SignalFunctionWrapper::pRuntime_, 0U);
+        return;
+      }
+    }
     if (trapCode != 0U) {
       handleTrap(uc, trapCode);
       return;


### PR DESCRIPTION
we can set the premission as RW to force stop the wasm execution. It can save lots of CPU cycle in check point.
It is a dirty POC for this concept, not the finally implementation.
