### PR TITLE
Allocate executable JIT code to read+execute memory directly

### DIFF
--- a/src/utils/ExecutableMemory.cpp
+++ b/src/utils/ExecutableMemory.cpp
@@ -57,22 +57,20 @@ void ExecutableMemory::init(uint8_t const *const data) {
     return;
   }
 
-  MemUtils::MmapMemory const mmapMemory{MemUtils::allocPagedMemory(size_)};
-  uint8_t *const readWriteMemory{mmapMemory.ptr};
+  MemUtils::MmapMemory const mmapMemory{MemUtils::allocPagedMemory(size_, data)};
+  uint8_t *const readWriteOrExecuteMemory{mmapMemory.ptr};
 
-  if (readWriteMemory != nullptr) {
+  if (readWriteOrExecuteMemory != nullptr) {
     fd_ = mmapMemory.fd;
-    MemUtils::memcpyAndClearInstrCache(readWriteMemory, data, size_);
+    data_ = readWriteOrExecuteMemory;
   } else {
     throw std::bad_alloc(); // GCOVR_EXCL_LINE
   }
 
-#ifdef __linux__
-  uint8_t *const readExecuteMemory{MemUtils::mapRXMemory(size_, fd_)};
-  data_ = readExecuteMemory;
-  MemUtils::freePagedMemory(readWriteMemory, size_);
+#if defined(__linux__) || defined(__QNX__)
+  MemUtils::clearInstructionCache(data_, size_);
 #else
-  data_ = readWriteMemory;
+  MemUtils::memcpyAndClearInstrCache(data_, data, size_);
   MemUtils::setPermissionRX(data_, size_);
 #endif
 }

--- a/src/utils/MemUtils.cpp
+++ b/src/utils/MemUtils.cpp
@@ -169,15 +169,15 @@ static void *alignedReduce(void *const ptr, size_t const size, size_t const alig
 /// @brief wrapper of mmap, throw std::bad_alloc when mmap failed
 /// @param addr bypass to mmap
 /// @param length bypass to mmap
-/// @param port bypass to mmap
+/// @param prot bypass to mmap
 /// @param flags bypass to mmap
 /// @param fd bypass to mmap
 /// @param offset bypass to mmap
 /// @return result of mmap when mmap success
 /// @throw throw std::bad_alloc when mmap failed
-static uint8_t *wrapperMmap(void *const addr, size_t const length, int32_t const port, int32_t const flags, int32_t const fd, off_t const offset) {
+static uint8_t *wrapperMmap(void *const addr, size_t const length, int32_t const prot, int32_t const flags, int32_t const fd, off_t const offset) {
   // coverity[autosar_cpp14_a16_2_3_violation]
-  void *const ptr{mmap(addr, length, port, flags, fd, offset)};
+  void *const ptr{mmap(addr, length, prot, flags, fd, offset)};
   // coverity[autosar_cpp14_a16_2_3_violation]
   // coverity[autosar_cpp14_a5_2_2_violation]
   // coverity[autosar_cpp14_m5_2_9_violation]
@@ -381,35 +381,42 @@ void memcpyAndClearInstrCache(uint8_t *const dest, uint8_t const *const source, 
   clearInstructionCache(dest, size);
 }
 
-MmapMemory allocPagedMemory(size_t const size) {
+MmapMemory allocPagedMemory(size_t const size, uint8_t const *const data) {
   MmapMemory mmapMemory{nullptr, -1};
 #ifdef VB_WIN32
   mmapMemory.ptr = allocAlignedMemory(size, getOSMemoryPageSize());
   return mmapMemory;
 #else
   size_t const alignedSize{roundUpToOSMemoryPageSize(size)};
-#ifdef __linux__
+#if defined(__linux__) || defined(__QNX__)
   static std::atomic<uint64_t> fileCounter{0U}; ///< counter of mmap files
   // coverity[autosar_cpp14_a16_2_3_violation]
   std::stringstream ss{};
   uint64_t const localCounter{fileCounter};
   fileCounter++;
   ss << getpid() << "_vb_wasm_mem" << localCounter;
+  #if defined(__linux__)
   int32_t const jitCodeMapFile{
       // coverity[autosar_cpp14_a16_2_3_violation]
       static_cast<int32_t>(syscall(__NR_memfd_create, ss.str().c_str(), MFD_CLOEXEC))}; // NOLINT(cppcoreguidelines-pro-type-vararg)
+  #elif defined __QNX__
+    // Instead of SHM_ANON, let's name the file
+    int32_t const jitCodeMapFile{shm_open(ss.str().c_str(), O_RDWR | O_CREAT, 0600)};
+  #endif
+
   if (jitCodeMapFile == -1) {
     return mmapMemory;
   }
 
   int32_t error{ftruncate(jitCodeMapFile, static_cast<off_t>(alignedSize))};
 
-  if (error != 0) {
+  if ((error != 0) || (write(jitCodeMapFile, data, size) == -1)) {
     error = close(jitCodeMapFile);
     static_cast<void>(error);
     assert(error == 0 && "close file failed");
     return mmapMemory;
   }
+
   // coverity[autosar_cpp14_a16_2_3_violation]
   constexpr int32_t flag{MAP_SHARED};
   mmapMemory.fd = jitCodeMapFile;
@@ -419,7 +426,11 @@ MmapMemory allocPagedMemory(size_t const size) {
   constexpr int32_t flag = static_cast<int32_t>(uflag);
 #endif
   // coverity[autosar_cpp14_a16_2_3_violation]
-  constexpr uint32_t prot{static_cast<uint32_t>(PROT_READ) | static_cast<uint32_t>(PROT_WRITE)};
+  uint32_t prot{static_cast<uint32_t>(PROT_READ) | static_cast<uint32_t>(PROT_WRITE)};
+  if(data != nullptr)
+  {
+    prot = static_cast<uint32_t>(PROT_READ) | static_cast<uint32_t>(PROT_EXEC);
+  }
   mmapMemory.ptr = wrapperMmap(nullptr, alignedSize, static_cast<int32_t>(prot), static_cast<int32_t>(flag), mmapMemory.fd, 0);
 
   return mmapMemory;

--- a/src/utils/MemUtils.cpp
+++ b/src/utils/MemUtils.cpp
@@ -388,20 +388,19 @@ MmapMemory allocPagedMemory(size_t const size, uint8_t const *const data) {
   return mmapMemory;
 #else
   size_t const alignedSize{roundUpToOSMemoryPageSize(size)};
-#if defined(__linux__) || defined(__QNX__)
-  static std::atomic<uint64_t> fileCounter{0U}; ///< counter of mmap files
-  // coverity[autosar_cpp14_a16_2_3_violation]
-  std::stringstream ss{};
-  uint64_t const localCounter{fileCounter};
-  fileCounter++;
-  ss << getpid() << "_vb_wasm_mem" << localCounter;
-  #if defined(__linux__)
-  int32_t const jitCodeMapFile{
+  #if defined(__linux__) || defined(__QNX__)
+    #if defined(__linux__)
+    static std::atomic<uint64_t> fileCounter{0U}; ///< counter of mmap files
+    // coverity[autosar_cpp14_a16_2_3_violation]
+    std::stringstream ss{};
+    uint64_t const localCounter{fileCounter};
+    fileCounter++;
+    ss << getpid() << "_vb_wasm_mem" << localCounter;
+    int32_t const jitCodeMapFile{
       // coverity[autosar_cpp14_a16_2_3_violation]
       static_cast<int32_t>(syscall(__NR_memfd_create, ss.str().c_str(), MFD_CLOEXEC))}; // NOLINT(cppcoreguidelines-pro-type-vararg)
   #elif defined __QNX__
-    // Instead of SHM_ANON, let's name the file
-    int32_t const jitCodeMapFile{shm_open(ss.str().c_str(), O_RDWR | O_CREAT, 0600)};
+    int32_t const jitCodeMapFile{SHM_ANON, O_RDWR | O_CREAT, 0600)};
   #endif
 
   if (jitCodeMapFile == -1) {
@@ -409,8 +408,7 @@ MmapMemory allocPagedMemory(size_t const size, uint8_t const *const data) {
   }
 
   int32_t error{ftruncate(jitCodeMapFile, static_cast<off_t>(alignedSize))};
-
-  if ((error != 0) || (write(jitCodeMapFile, data, size) == -1)) {
+  if ((error != 0) || (data == nullptr) || (write(jitCodeMapFile, data, size) == -1)) {
     error = close(jitCodeMapFile);
     static_cast<void>(error);
     assert(error == 0 && "close file failed");
@@ -418,13 +416,15 @@ MmapMemory allocPagedMemory(size_t const size, uint8_t const *const data) {
   }
 
   // coverity[autosar_cpp14_a16_2_3_violation]
-  constexpr int32_t flag{MAP_SHARED};
+  constexpr int32_t flag{MAP_PRIVATE};
   mmapMemory.fd = jitCodeMapFile;
-#else
-  mmapMemory.fd = -1;
-  constexpr uint32_t uflag = static_cast<uint32_t>(MAP_ANONYMOUS) | static_cast<uint32_t>(MAP_PRIVATE);
-  constexpr int32_t flag = static_cast<int32_t>(uflag);
-#endif
+
+  #else
+    mmapMemory.fd = -1;
+    constexpr uint32_t uflag = static_cast<uint32_t>(MAP_ANONYMOUS) | static_cast<uint32_t>(MAP_PRIVATE);
+    constexpr int32_t flag = static_cast<int32_t>(uflag);
+  #endif
+
   // coverity[autosar_cpp14_a16_2_3_violation]
   uint32_t prot{static_cast<uint32_t>(PROT_READ) | static_cast<uint32_t>(PROT_WRITE)};
   if(data != nullptr)

--- a/src/utils/MemUtils.hpp
+++ b/src/utils/MemUtils.hpp
@@ -113,10 +113,11 @@ struct MmapMemory final {
 /// @brief Allocate page aligned memory
 ///
 /// @param size size of to be allocated memory
+/// @param data pointer to be mapped as an anonymous file
 /// @throw std::bad_alloc memory allocation failed
 /// @return MmapMemory
 ///
-MmapMemory allocPagedMemory(size_t const size);
+MmapMemory allocPagedMemory(size_t const size, uint8_t const *const data = nullptr);
 ///
 /// @brief Free page aligned memory
 ///


### PR DESCRIPTION
This prevents a sensitive transition from read+write to read+execute